### PR TITLE
Add png tile creation command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,11 @@ RUN cd /tmp && git clone https://github.com/openstreetmap/mod_tile.git && \
     make install && \
     make install-mod_tile && \
     ldconfig && \
+    # Build to meta2tile utility and copy onto system path
+    cd extra && \
+    make && \
+    cp meta2tile /usr/local/bin && \
+    # Tidy up
     cd /tmp && rm -rf /tmp/mod_tile
 
 RUN cp -p /usr/local/etc/renderd.conf /usr/local/etc/renderd.conf.orig

--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ $ docker-compose run --rm app-osm render
 $ docker-compose up -d
 ```
 
+### Creating .png format tiles
+
+By default, tiles are created in .meta format.  To convert these to .png format
+in an /z/x/y/ directory structure, run the following once the render process
+is complete:
+
+```sh
+$ docker-compose run --rm app-osm create-pngs
+```
+
+The tiles will be created in the _png_ directory within the nvtiles volume.
+
+
 ### Direct Usage
 
 Initialise if not already done (initdb+import+render) and Start OSM server (startservices)

--- a/build/run.sh
+++ b/build/run.sh
@@ -170,6 +170,13 @@ startweb () {
     _startservice apache2
 }
 
+create_pngs () {
+    echo "Creating png tiles from .meta files using meta2tile"
+    mkdir /var/lib/mod_tile/png
+    chown www-data:www-data -R /var/lib/mod_tile/png
+    $asweb meta2tile /var/lib/mod_tile/default /var/lib/mod_tile/png
+}
+
 help () {
     cat /usr/local/share/doc/run/help.txt
     exit


### PR DESCRIPTION
This commit alters the Dockerfile to compile the meta2tile utility and
add it to the system path.  It adds an extra command to the run()
function to call it externally to convert all existing rendered tiles.